### PR TITLE
Fix on deployment

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -1,11 +1,5 @@
 name: Create and publish a Docker image
 
-# secrets necessarios:
-  # DEV_AWS_ACCESS_KEY_ID
-  # DEV_AWS_SECRET_ACCESS_KEY
-  # PROD_AWS_ACCESS_KEY_ID
-  # PROD_AWS_SECRET_ACCESS_KEY
-
 on:
   push:
     branches: 
@@ -18,19 +12,9 @@ env:
   IMAGE_TAG: ${{ github.sha }}
 
   DEV_BRANCH: develop
-  DEV_AWS_REGION: sa-east-1
-  DEV_ECS_CLUSTER: sos-rs-freetier-ec2_cluster
-  DEV_ECS_SERVICE: sos-rs-freetier-backend
-  DEV_ECS_CONTAINER_NAME: server
-  DEV_ECS_TASK_DEFINITION: sos-rs-freetier-backend
-
-  PROD_AWS_REGION: sa-east-1
   PROD_BRANCH: main
-  PROD_REGION: sa-east-1
-  PROD_ECS_CLUSTER: sos-rs-freetier-ec2_cluster
-  PROD_ECS_SERVICE: sos-rs-freetier-backend
-  PROD_ECS_CONTAINER_NAME: server
-  PROD_ECS_TASK_DEFINITION: sos-rs-freetier-backend
+
+  PORT: 4000
 
 jobs:
   build:
@@ -81,77 +65,50 @@ jobs:
     if: github.ref == 'refs/heads/develop'
 
     runs-on: ubuntu-latest
-    permissions:
-      packages: read
     needs: [build]
-    env:
-      CONTAINER_IMAGE: ${{ needs.build.outputs.container_image }}
     steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4.0.2
-        with:
-          aws-access-key-id: ${{ secrets.DEV_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.DEV_AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ env.DEV_AWS_REGION }}
+      - uses: actions/checkout@v4
 
-      - name: Fetch task definition
-        id: fetch-task-definition
+      - name: SSH Client
+        run: sudo apt-get install -y openssh-client
+
+      - name: SSH Config Key
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY_DIG_OC }}
+
+      - name: Pull and run the Docker image
         run: |
-          aws ecs describe-task-definition --task-definition ${{ env.DEV_ECS_TASK_DEFINITION }} --query taskDefinition > task-definition.json
-
-      - name: Update container image in task definition
-        id: update-image
-        uses: aws-actions/amazon-ecs-render-task-definition@v1.3.0
-        with:
-          task-definition: task-definition.json
-          container-name: ${{ env.DEV_ECS_CONTAINER_NAME }}
-          image: ${{ env.CONTAINER_IMAGE }}
-
-      - name: Deploy to Amazon ECS
-        uses: aws-actions/amazon-ecs-deploy-task-definition@v1.5.0
-        with:
-          task-definition: ${{ steps.update-image.outputs.task-definition }}
-          service: ${{ env.DEV_ECS_SERVICE }}
-          cluster: ${{ env.DEV_ECS_CLUSTER }}
-          wait-for-service-stability: true
-          force-new-deployment: true
+          ssh -o StrictHostKeyChecking=no root@${{ secrets.DEV_DROPLET_IP }} << 'EOF'
+            docker login ${{ env.IMAGE_REGISTRY }} -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
+            docker pull ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+            docker stop $(docker ps -q) || true
+            docker rm $(docker ps -aq) || true
+            docker run -dit --name sos-rs-api -p ${{ env.PORT }}:${{ env.PORT }} ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+          EOF
 
   deploy-prod:
     if: github.ref == 'refs/heads/main'
 
     runs-on: ubuntu-latest
-    permissions:
-      packages: read
     needs: [build]
-    env:
-      CONTAINER_IMAGE: ${{ needs.build.outputs.container_image }}
     steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4.0.2
+      - uses: actions/checkout@v4
+
+      - name: SSH Client Install
+        run: sudo apt-get install -y openssh-client
+
+      - name: SSH Config Key
+        uses: webfactory/ssh-agent@v0.9.0
         with:
-          aws-access-key-id: ${{ secrets.PROD_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.PROD_AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ env.PROD_AWS_REGION }}
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY_DIG_OC }}
 
-      - name: Fetch task definition
-        id: fetch-task-definition
-        run: DEV|
-          aws ecs describe-task-definition --task-definition ${{ env.PROD_ECS_TASK_DEFINITION }} --query taskDefinition > task-definition.json
-
-      - name: Update container image in task definition
-        id: update-image
-        uses: aws-actions/amazon-ecs-render-task-definition@v1.3.0
-        with:
-          task-definition: task-definition.json
-          container-name: ${{ env.PROD_ECS_CONTAINER_NAME }}
-          image: ${{ env.CONTAINER_IMAGE }}
-
-      - name: Deploy to Amazon ECS
-        uses: aws-actions/amazon-ecs-deploy-task-definition@v1.5.0
-        with:
-          task-definition: ${{ steps.update-image.outputs.task-definition }}
-          service: ${{ env.PROD_ECS_SERVICE }}
-          cluster: ${{ env.PROD_ECS_CLUSTER }}
-          wait-for-service-stability: false
-          force-new-deployment: true
-
+      - name: Pull and run the Docker image
+        run: |
+          ssh -o StrictHostKeyChecking=no root@${{ secrets.PROD_DROPLET_IP }} << 'EOF'
+            docker login ${{ env.IMAGE_REGISTRY }} -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
+            docker pull ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+            docker stop $(docker ps -q) || true
+            docker rm $(docker ps -aq) || true
+            docker run -dit --name sos-rs-api -p ${{ env.PORT }}:${{ env.PORT }} ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+          EOF


### PR DESCRIPTION
Foi realizado o ajuste de uma maneira genérica para a pipeline executar nos Droplets. 

Segui o mesmo padrão do anterior, utilizando apenas DEV e PRD, também foi reutilizado seu build.

Para a etapa de deploy funcionar será preciso definir algumas novas secrets em seu ambiente, são elas:
SSH_PRIVATE_KEY_DIG_OC -> Chave SSH para se conectar nas máquinas
DEV_DROPLET_IP e PROD_DROPLET_IP -> IPs das respectivas máquinas para a conexão ssh

Como não utilizei tanto o Actions em projetos, não sei se ele tem algo como o Extends do GITLAB-CI, mas validarei mais pra frente para deixar muito mais simples limar o tamanho desse deployment.

Qualquer dúvida pode falar comigo pelo Discord.